### PR TITLE
Custom dotfiles path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <b>H</b>idden <b>F</b>iles <b>A</b>re <b>M</b>anageable - Manage, source and reload you dotfiles in a specific directory
 
-1. You create/clone your `dotfiles` directory defined in `$HOME/`. 
-2. You edit a `$HOME/dotfiles/.hfamconfig` with its intuitive DSL.
+1. You create/clone your `dotfiles`. 
+2. You edit a `dotfiles/.hfamconfig` file with its intuitive DSL.
 3. You call `hfam`.
 
 The main advantage of this tool is that you can easily move your `dotfiles` from a machine to another one. Then, with only one command, you can configure your environment.
@@ -45,26 +45,45 @@ Example
      |- .hfamconfig
 ```
 
-###Options
+####Options
 
 Option `-h --help`
 
-Display usage:
+Display the usage:
 
 ```shell
 ?> hfam --help
+HFAM - Hidden Files Are Manageable
 
+Centralize your dotfiles in one directory and manage them using some basic operations (symlink, source, ...)
+This tool attempts to locate a ~/dotfiles/.hfamconfig file. Then it executes a set of commands
+listed in the config file.
+
+For further information: https://github.com/mehdi-farsi/hfam
+
+USAGE:
+
+hfam [-h|--help] [-p|--path]
+
+OPTIONS:
+
+-h  # help
+-p  # change the default dotfiles path
 ```
 
 Option `-p --path`
 
+Change the default dotfiles path.
+
 ```shell
 ?> hfam --path /Users/zoidberg/Documents/dotfiles
-Symlink: ln -s /Users/mehdi/Documents/dotfiles/testpath /Users/zoidberg/Documents/.testpath
+Symlink: ln -s /Users/mehdi/Documents/dotfiles/testpath /Users/zoidberg/Documents/dotfiles/.testpath
 ```
 
 > The path set by --path option is the default symlink target path.
 > use the DSL symlink option `:dest` to override this path.
+
+####Hfamconfig
 
 `hfam` works with a `.hfamconfig` file. This config file provide an intuitive DSL for managing your dotfiles.
 
@@ -77,7 +96,7 @@ For the following examples, let's say that the following environment variables a
 
 Now, let's have look to the `.hfamconfig` DSL.
 
-####Symlink
+#####Symlink
 
 The `symlink` command creates a symlink with the source file passed as argument. The symlink target is created in `$HOME/.target`.
 
@@ -119,7 +138,7 @@ Symlink: ln -s /Users/mehdi/dotfiles/gitignore /Users/zoidberg/apps/my_app/.giti
 > lrwxr-xr-x  1 lol  cat 27B Nov 11 16:35 .gitconfig -> /Users/zoidberg/dotfiles/gitconfig
 > ```
 
-####Source
+#####Source
 
 The `source` command creates a symlink using the file passed as argument and source the symlink target. The symlink target file is defined at `$HOME/.target`.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ Example
      |- .hfamconfig
 ```
 
+###Options
+
+Option `-h --help`
+
+Display usage:
+
+```shell
+?> hfam --help
+
+```
+
+Option `-p --path`
+
+```shell
+?> hfam --path /Users/zoidberg/Documents/dotfiles
+Symlink: ln -s /Users/mehdi/Documents/dotfiles/testpath /Users/zoidberg/Documents/.testpath
+```
+
+> The path set by --path option is the default symlink target path.
+> use the DSL symlink option `:dest` to override this path.
 
 `hfam` works with a `.hfamconfig` file. This config file provide an intuitive DSL for managing your dotfiles.
 

--- a/lib/hfam/application.rb
+++ b/lib/hfam/application.rb
@@ -9,8 +9,8 @@ module HFAM
     end
 
     def run
-      if @payload.metadata.include? :help
-        puts @payload.metadata[:help]
+      if @payload.help_option?
+        puts @payload.help_message
         return
       end
 

--- a/lib/hfam/argument_parser.rb
+++ b/lib/hfam/argument_parser.rb
@@ -6,12 +6,17 @@ module HFAM
       options = {}
 
       o = ::OptionParser.new do |opts|
+
         opts.banner = ::HFAM::HELP
         
-
-        opts.on("-h") do |h|
+        opts.on("-h", "--help") do |h|
           options[:help] = ::HFAM::HELP
         end
+
+        opts.on("-p=PATH", "--path=PATH") do |p|
+          options[:path] = p
+        end
+
       end
     begin
       o.parse!

--- a/lib/hfam/constants.rb
+++ b/lib/hfam/constants.rb
@@ -1,7 +1,6 @@
 module HFAM
-  HOME                 = "#{ENV['HOME']}"
-  DEFAULT_DOTFILE_PATH = "#{ENV['HOME']}/dotfiles"
-  HFAMCONFIG_PATH      = "#{DEFAULT_DOTFILE_PATH}/.hfamconfig"
+  HOME                  = "#{ENV['HOME']}"
+  DEFAULT_DOTFILES_PATH = "#{ENV['HOME']}/dotfiles"
 
   HELP = <<-SHELL
 HFAM - Hidden Files Are Manageable

--- a/lib/hfam/constants.rb
+++ b/lib/hfam/constants.rb
@@ -13,11 +13,11 @@ For further information: https://github.com/mehdi-farsi/hfam
 
 USAGE:
 
-hfam [-h]
+hfam [-h|--help] [-p|--path]
 
 OPTIONS:
 
 -h  # help
-
+-p  # change the default dotfiles path
 SHELL
 end

--- a/lib/hfam/dsl.rb
+++ b/lib/hfam/dsl.rb
@@ -10,12 +10,12 @@ module HFAM
     end
 
     def symlink(file, options = {})
-      @payload.commands << [:symlink, "#{dotfiles_path}/#{file}", dest_path(file, options)]
+      @payload.commands << [:symlink, "#{dotfiles_path}/#{file}", dest_path(options)]
     end
 
     def source(file, options = {})
       symlink(file)
-      @payload.commands << [:source, "#{dotfiles_path}/#{file}", dest_path(file, options)]
+      @payload.commands << [:source, "#{dotfiles_path}/#{file}", dest_path(options)]
     end
 
     def route
@@ -28,11 +28,13 @@ module HFAM
 
   private
     def dotfiles_path
-      @payload.metadata[:path] || DEFAULT_DOTFILES_PATH
+      # File::expand_path convert the builtin "~/" to the path defined in ENV["HOME"]
+      File.expand_path(@payload.metadata[:path] || DEFAULT_DOTFILES_PATH)
     end
 
-    def dest_path(file, options = {})
-      options.include?(:dest) ? options[:dest] : ::HFAM::HOME
+    def dest_path(options = {})
+      # File::expand_path convert the builtin "~/" to the path defined in ENV["HOME"]
+      File.expand_path(options[:dest] || ::HFAM::HOME)
     end
   end
 end

--- a/lib/hfam/dsl.rb
+++ b/lib/hfam/dsl.rb
@@ -6,16 +6,16 @@ module HFAM
     end
 
     def tokenize
-      raw_commands = eval(::File.open(::HFAM::HFAMCONFIG_PATH).read)
+      raw_commands = eval(::File.open("#{dotfiles_path}/.hfamconfig").read)
     end
 
     def symlink(file, options = {})
-      @payload.commands << [:symlink, "#{DEFAULT_DOTFILE_PATH}/#{file}", dest_path(file, options)]
+      @payload.commands << [:symlink, "#{dotfiles_path}/#{file}", dest_path(file, options)]
     end
 
     def source(file, options = {})
       symlink(file)
-      @payload.commands << [:source, "#{DEFAULT_DOTFILE_PATH}/#{file}", dest_path(file, options)]
+      @payload.commands << [:source, "#{dotfiles_path}/#{file}", dest_path(file, options)]
     end
 
     def route
@@ -24,6 +24,11 @@ module HFAM
 
     def method_missing(method, *args, &block)
       @payload.commands << [:unknown, { command: method, args: args }]
+    end
+
+  private
+    def dotfiles_path
+      @payload.metadata[:path] || DEFAULT_DOTFILES_PATH
     end
 
     def dest_path(file, options = {})

--- a/lib/hfam/payload.rb
+++ b/lib/hfam/payload.rb
@@ -8,6 +8,14 @@ module HFAM
       self[:commands] = Array.new { |value| [:unknown, value] }
     end
 
+    def help_option?
+      !!metadata[:help]
+    end
+
+    def help_message
+      metadata[:help]
+    end
+
     def metadata
       self[:metadata]
     end


### PR DESCRIPTION
- [x] add option `--path`
- [x] use the path into the DSL
- [x] update README.md
  - [x] about `--path` option
  - [x] the path set by `--path` option is the default `symlink` target path.
  - [x] use the DSL symlink option `:dest` to override this path.