### PR TITLE
hfam-unlink command

### DIFF
--- a/bin/hfam-unlink
+++ b/bin/hfam-unlink
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+# Unlink dead symlink
+# A dead symlink is a link that the target cannot be reached

--- a/bin/hfam-unlink
+++ b/bin/hfam-unlink
@@ -2,3 +2,13 @@
 
 # Unlink dead symlink
 # A dead symlink is a link that the target cannot be reached
+
+require "fileutils"
+require "pathname"
+
+# Get all hidden file at root or a specified path
+# For each files:
+# => check if it's a symlink
+# => try to reach the real path
+# => check if the target exists
+# => if not remove the symlink

--- a/lib/hfam/application.rb
+++ b/lib/hfam/application.rb
@@ -14,9 +14,9 @@ module HFAM
     end
 
     def run
-      # dsl = ::HFAM::DSL.new(@payload).tokenize
+      dsl = ::HFAM::DSL.new(@payload).tokenize
 
-      # @command_set.dispatch_commands(@payload)
+      @command_set.dispatch_commands(@payload)
     end
   end
 end

--- a/lib/hfam/version.rb
+++ b/lib/hfam/version.rb
@@ -1,3 +1,3 @@
 module HFAM
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Unlink all dead symlinks.

A dead symlink is a symlink of which the target cannot be reached
